### PR TITLE
[FIX] chat DM 기능 수정

### DIFF
--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -7,9 +7,10 @@ import { User } from '../common/entities/user.entity';
 import { ChatUser } from '../common/entities/chatuser.entity';
 import { ChatGateway } from './chat.gateway';
 import { RepositoryModule } from '../repository/repository.module';
+import { Block } from 'src/common/entities/block.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ChatRoom, ChatUser, User]), RepositoryModule],
+  imports: [TypeOrmModule.forFeature([ChatRoom, ChatUser, User, Block]), RepositoryModule],
   controllers: [ChatController],
   providers: [ChatService, ChatGateway],
 })

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -113,8 +113,8 @@ export class ChatService {
 
   async createDMRoom(userId: number, newRoomInfo: newChatRoomDto): Promise<ChatRoomDto> {
     const inviter: User = await this.findExistUser(userId);
-    if (!newRoomInfo.dmId) throw new BadRequestException('DM need a target user');
-    const invitee: User= await this.findExistUser(newRoomInfo.dmId);
+    if (!newRoomInfo.userId) throw new BadRequestException('DM need a target user');
+    const invitee: User= await this.findExistUser(newRoomInfo.userId);
 
     const blocking: Block = await this.blockRepository.findOne({ where: { toId: invitee.id, fromId: inviter.id }});
     const blocked: Block = await this.blockRepository.findOne({ where: {  toId: inviter.id, fromId: invitee.id }});
@@ -124,7 +124,7 @@ export class ChatService {
     newRoomInfo.password = null;
     const newRoom = await this.chatRoomRepository.save(newRoomInfo.toChatRoomEntity());
     await this.enterChatOwner(newRoom.id, userId);
-    await this.enterChatOwner(newRoom.id, newRoomInfo.dmId);
+    await this.enterChatOwner(newRoom.id, newRoomInfo.userId);
     return new ChatRoomDto(newRoom.id, newRoom.roomName, newRoom.roomMode);
   }
 

--- a/src/chat/dto/request/new-chat-room.dto.ts
+++ b/src/chat/dto/request/new-chat-room.dto.ts
@@ -13,7 +13,7 @@ export class newChatRoomDto {
   password: string;
 
   @IsOptional()
-  dmId: number;
+  userId: number;
 
   public toChatRoomEntity() {
     return ChatRoom.from(this.roomName, this.roomMode, this.password);


### PR DESCRIPTION
DM인 경우, 방 이름을 상대방의 이름으로 보내줍니다.
상대방의 이름이 변경된 경우에서도 작동합니다.
enterChatOwner에서 createChatOwner로 함수명을 변경하고 joinChatRoom 기능을 분리하였습니다.
addedRoom, joinChatroom의 순서를 변경하였습니다.
